### PR TITLE
fix NTT bugs

### DIFF
--- a/aten/src/ATen/native/zkp/cuda/zksnark_ntt/ntt_kernel/kernels.cuh
+++ b/aten/src/ATen/native/zkp/cuda/zksnark_ntt/ntt_kernel/kernels.cuh
@@ -32,13 +32,13 @@ __device__ __forceinline__ void get_intermediate_roots(
   int win = (WINDOW_NUM - 1) * LG_WINDOW_SIZE;
   int off = (WINDOW_NUM - 1);
 
-  root0 = roots[off * WINDOW_SIZE + idx0 >> win];
-  root1 = roots[off * WINDOW_SIZE + idx1 >> win];
+  root0 = roots[off * WINDOW_SIZE + (idx0 >> win)];
+  root1 = roots[off * WINDOW_SIZE + (idx1 >> win)];
 #pragma unroll 1
   while (off--) {
     win -= LG_WINDOW_SIZE;
-    root0 *= roots[off * WINDOW_SIZE + (idx0 >> win) % WINDOW_SIZE];
-    root1 *= roots[off * WINDOW_SIZE + (idx1 >> win) % WINDOW_SIZE];
+    root0 *= roots[off * WINDOW_SIZE + ((idx0 >> win) % WINDOW_SIZE)];
+    root1 *= roots[off * WINDOW_SIZE + ((idx1 >> win) % WINDOW_SIZE)];
   }
 }
 


### PR DESCRIPTION
Fix NTT bug caused by operator precedence here:
```
root0 = roots[off * WINDOW_SIZE + (idx0 >> win)];
root1 = roots[off * WINDOW_SIZE + (idx1 >> win)];
```
It should be 
```  
root0 = roots[off * WINDOW_SIZE + **(idx0 >> win)**];
root1 = roots[off * WINDOW_SIZE + **(idx1 >> win)**];
```